### PR TITLE
ボタンの認識と割り込みの間隔の変更　Seshimo/copy ma　

### DIFF
--- a/mips/hard/top.v
+++ b/mips/hard/top.v
@@ -14,7 +14,7 @@ module fpga_top (
 	input		[3:0]	btn,
 	output 	reg	[3:0]	led,
 	output 	reg	[10:0]	lcd,
-	output	reg	[7:0]	ioa,
+	input		[3:0]	ioa,
 	output	reg	[7:0]	iob,
 	input		[3:0]	ioc
 
@@ -24,7 +24,7 @@ module fpga_top (
 wire	[31:0]	pc, instr, readdata, readdata0, readdata1, readdata5, readdata6, writedata, dataadr;
 wire	[3:0]	byteen;
 wire		reset;
-wire		memwrite, memtoregM, swc, cs0, cs1, cs2, cs3, cs4, cs5, irq;
+wire		memwrite, memtoregM, swc, cs0, cs1, cs2, cs3, cs4, cs5, cs6, irq;
 reg		clk_62p5mhz;
 
 reg [7:0] mode;

--- a/mips/soft/button.c
+++ b/mips/soft/button.c
@@ -11,9 +11,9 @@
  * btn_states_update()はmain()の中で定期的に呼び出す必要がある
  */
 
-#define IO_A_ADDR 0xff18  // between display and speaker
+#define IO_A_ADDR 0xff18 // between display and speaker
 // #define IO_B_ADDR 0xff10  // speaker
-#define IO_C_ADDR 0xff14  // under the display
+#define IO_C_ADDR 0xff14 // under the display
 #define BTN_ADDR 0xff04
 #define BUTTON_NUM 6
 
@@ -28,48 +28,55 @@ int btn_check_c();
 int btn_states[BUTTON_NUM];
 
 // ボタンの状態を取得する
-int btn_get_state(int button_num) {
+int btn_get_state(int button_num)
+{
   int state = btn_states[button_num];
   btn_states[button_num] = 0;
   return state;
 }
 
 // ボタンの状態を更新する
-void btn_states_update() {
+void btn_states_update()
+{
   int i;
-  for (i = 0; i < 4; i++) {
+  for (i = 0; i < 4; i++)
+  {
     btn_states[i] = btn_check_num(i);
   }
   btn_states[4] = btn_check_a();
   btn_states[5] = btn_check_c();
 }
 
-int btn_check_num(int button_num) {
+int btn_check_num(int button_num)
+{
   volatile int *btn_ptr = (int *)BTN_ADDR;
-  switch (button_num) {
-    case 0:
-      return (*btn_ptr & 0x10) ? 1 : 0;
-      break;
-    case 1:
-      return (*btn_ptr & 0x20) ? 1 : 0;
-      break;
-    case 2:
-      return (*btn_ptr & 0x40) ? 1 : 0;
-      break;
-    case 3:
-      return (*btn_ptr & 0x80) ? 1 : 0;
-      break;
-    default:
-      return 0;
+  switch (button_num)
+  {
+  case 0:
+    return (*btn_ptr & 0x10) ? 1 : 0;
+    break;
+  case 1:
+    return (*btn_ptr & 0x20) ? 1 : 0;
+    break;
+  case 2:
+    return (*btn_ptr & 0x40) ? 1 : 0;
+    break;
+  case 3:
+    return (*btn_ptr & 0x80) ? 1 : 0;
+    break;
+  default:
+    return 0;
   }
 }
 
-int btn_check_a() {
+int btn_check_a()
+{
   volatile int *sw_ptr = (int *)IO_A_ADDR;
   return (*sw_ptr & 0x1) ? 1 : 0;
 }
 
-int btn_check_c() {
+int btn_check_c()
+{
   volatile int *sw_ptr = (int *)IO_C_ADDR;
   return (*sw_ptr & 0x1) ? 1 : 0;
 }


### PR DESCRIPTION
IOCとIOAのボタンの認識が出きるようにした。

lcdの表示がよく見えるように、割り込みの間隔を0.1秒に一回に戻した。